### PR TITLE
Loader options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Now run node with the `--experimental-loader` flag:
 node --experimental-loader @node-loader/http file.js
 ```
 
+If you use @node-loader/core, you can pass down options to the loader.
+
+```js
+const HttpsProxyAgent = require("https-proxy-agent");
+
+export default {
+  loaders: [
+    {
+      options: {
+        fetchOptions: {
+          agent: new HttpsProxyAgent("http://123.123.123.123"),
+        },
+      },
+      loader: httpLoader,
+    },
+  ],
+};
+```
+
 ## Semantics
 
 This project uses [node-fetch](https://github.com/node-fetch/node-fetch) to implement familiar HTTP semantics,

--- a/lib/node-loader-http.js
+++ b/lib/node-loader-http.js
@@ -25,7 +25,7 @@ export function resolve(specifier, context, defaultResolve) {
   return defaultResolve(specifier, context, defaultResolve);
 }
 
-export async function load(url, context, defaultLoad) {
+export async function load(url, context, defaultLoad, loaderOptions) {
   if (useLoader(url)) {
     let format;
     // TODO: maybe change to content-type / mime type check rather than file extensions
@@ -46,7 +46,10 @@ export async function load(url, context, defaultLoad) {
 
     let source;
 
-    const httpResponse = await fetch(url);
+    const httpResponse = await fetch(
+      url,
+      loaderOptions ? loaderOptions.fetchOptions : undefined
+    );
 
     if (httpResponse.ok) {
       source = await httpResponse.text();

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 
 describe(`basic http / https tests`, () => {
-  it(`can load a module over http`, async () => {
+  it.only(`can load a module over http`, async () => {
     const ns = await import(
       "http://unpkg.com/single-spa@5.5.5/lib/esm/single-spa.dev.js"
     );


### PR DESCRIPTION
Issue: #5

I'm not sure how to pass options without using the core loader. I also haven't been able to add any options via the tests, I'm guessing I have to refactor the tests to use the core loader config?

Standing by for inputs.